### PR TITLE
Revert to WinForms, fix bugs, add CI/CD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Get version
+        id: version
+        shell: pwsh
+        run: |
+          $version = ([xml](Get-Content src/EoPatcher.UI/EoPatcher.UI.csproj)).Project.PropertyGroup.AssemblyVersion
+          echo "version=$version" >> $env:GITHUB_OUTPUT
+
+      - name: Publish
+        shell: pwsh
+        run: |
+          dotnet publish src/EoPatcher.UI/EoPatcher.UI.csproj `
+            -c Release `
+            -r win-x64 `
+            --self-contained true `
+            -p:PublishSingleFile=true `
+            -p:PublishTrimmed=false `
+            -o publish
+
+      - name: Create or update release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          make_latest: true
+          files: publish/eopatcher.exe

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# Endless Online Patcher
+
+## Project Overview
+A WinForms patcher for the MMO [Endless Online](https://endless-online.com). The primary deployment target is **Steam Deck via Proton** — the `.exe` is added to Steam as a non-Steam game with a Proton compatibility layer, allowing Steam Deck users to patch and launch EO without leaving the Steam environment.
+
+## Architecture
+
+```
+src/
+  EoPatcher.Core/   — net8.0, business logic (no Windows dependency)
+  EoPatcher.UI/     — net8.0-windows, WinForms custom-skinned UI
+```
+
+### Core Components
+| File | Role |
+|---|---|
+| `ServerVersionFetcher` | TCP-connects to `game.endless-online.com:8078`, sends an EO init packet, reads the server's reported client version number |
+| `LocalVersionRepository` | Reads/writes `version.txt` (relative to CWD) to track the locally installed version |
+| `HttpService` | Scrapes `endless-online.com/client/download.html` for the latest zip link; downloads with progress reporting |
+| `FileService` | Extracts the patch zip and copies files to the EO install directory; skips `config/` to preserve local settings |
+| `PatchOrchestrator` | Coordinates: clean temp files → download → extract → save version; implements `IDisposable` for cleanup |
+| `EndlessOnlineDirectory` | Resolves EO install path: checks `../Endless.exe` first (patcher expected at `Endless Online/Patcher/eopatcher.exe`), falls back to `C:/Program Files (x86)/Endless Online/` |
+| `Windows.StartEO` | Launches `Endless.exe` via Win32 token duplication so EO runs as the desktop (non-elevated) user |
+
+### UI
+The form is borderless and custom-skinned with EO assets. Window dragging is handled manually via `MouseDown/Move/Up`. All image buttons swap to hover variants on `MouseEnter`.
+
+Button states:
+- On load: all hidden while fetching versions
+- Up to date: Launch + Exit shown
+- Update available: Patch + Skip + Exit shown (Skip = launch without patching)
+- Error connecting: Launch + Exit shown (allows launching without version check)
+
+## Build
+
+Single self-contained Windows exe:
+```bash
+dotnet publish src/EoPatcher.UI/EoPatcher.UI.csproj \
+  -c Release -r win-x64 \
+  --self-contained true \
+  -p:PublishSingleFile=true \
+  -o ./publish
+```
+Output: `publish/eopatcher.exe`
+
+## Releasing
+
+Push to `main` triggers `.github/workflows/release.yml` which builds and uploads `eopatcher.exe` to a GitHub Release tagged `v{AssemblyVersion}`. To cut a new versioned release, bump `AssemblyVersion` and `FileVersion` in `src/EoPatcher.UI/EoPatcher.UI.csproj` before pushing.
+
+## Steam Deck / Proton Notes
+
+- The patcher is a Windows `.exe` running under Proton — add it to Steam as a non-Steam game, set Proton as the compatibility tool
+- `EndlessOnlineDirectory` resolves paths using Windows-style paths (`C:/Program Files (x86)/...`), which map correctly to the Wine prefix under Proton
+- `Windows.StartEO` uses Win32 token duplication to launch EO as a non-elevated process. **Under Proton, this may not work** if Wine's Explorer shell (which provides the shell window handle) is absent. If EO fails to launch, the fallback would be a simple `Process.Start(EndlessOnlineDirectory.GetExe())`
+
+## Known Issues / Todo
+- No EO directory picker UI — only auto-detects `../Endless.exe` or falls back to default install path
+- No auto-launch config option (launch after patch without clicking)
+- `Windows.StartEO` may need a Proton-compatible fallback (see above)
+- No test suite
+- News embed not implemented

--- a/src/EoPatcher.Core/Services/FileService.cs
+++ b/src/EoPatcher.Core/Services/FileService.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.IO.Compression;
 using System.Text.RegularExpressions;
+using System.Threading;
 
 namespace EoPatcher.Core.Services;
 
@@ -27,6 +28,7 @@ public class FileService : IFileService
         ZipFile.ExtractToDirectory("patch.zip", patchFolder);
         var patchFiles = Directory.EnumerateFiles(patchFolder, "*", SearchOption.AllDirectories)
             .Select(x => x.Remove(0, patchFolder.Length))
+            .Where(x => !x.StartsWith("config", StringComparison.OrdinalIgnoreCase))
             .ToList();
 
         var completed = 0;
@@ -40,11 +42,10 @@ public class FileService : IFileService
 
                 File.Copy($"{patchFolder}/{file}", $"{localDirectory}/{file}", true);
 
-                completed++;
-
-                var percent = 100f * completed / patchFiles.Count;
+                var count = Interlocked.Increment(ref completed);
+                var percent = 100f * count / patchFiles.Count;
 #if DEBUG
-                Debug.WriteLine($"Copying {file} to {localDirectory}/{file} {completed}/{patchFiles.Count} {percent}%");
+                Debug.WriteLine($"Copying {file} to {localDirectory}/{file} {count}/{patchFiles.Count} {percent}%");
 #endif
                 _setPatchTextCallback($"Extracting... {(int)percent}%");
             }));

--- a/src/EoPatcher.Core/Services/VersionFetchers/ServerVersionFetcher.cs
+++ b/src/EoPatcher.Core/Services/VersionFetchers/ServerVersionFetcher.cs
@@ -21,7 +21,12 @@ public partial class ServerVersionFetcher : IServerVersionFetcher
         Debug.WriteLine($"Connecting to {serverAddress}...");
         try
         {
-            client.Connect(serverAddress, serverPort);
+            var connected = client.ConnectAsync(serverAddress, serverPort).Wait(TimeSpan.FromSeconds(10));
+            if (!connected)
+            {
+                Debug.WriteLine($"Timed out connecting to {serverAddress}:{serverPort}");
+                return new Error<string>($"Timed out connecting to {serverAddress}:{serverPort}");
+            }
             Debug.WriteLine("Connected!");
 
             byte[] buf = [0xFF, 0xFF, 0x1E, 0x12, 0xFE, 0x1, 0x5, 0x2, 0x72, 0xB, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30, 0x30];

--- a/src/EoPatcher.UI/Main.cs
+++ b/src/EoPatcher.UI/Main.cs
@@ -22,18 +22,18 @@ public partial class Main : Form
         InitializeComponent();
     }
 
-    private void Main_Shown(object sender, EventArgs e)
+    private async void Main_Shown(object sender, EventArgs e)
     {
-        string version = Assembly.GetEntryAssembly().GetName().Version.ToString() ?? "0.0.0.0";
+        string version = Assembly.GetEntryAssembly()?.GetName().Version?.ToString() ?? "0.0.0.0";
         lblTitle.Text = $"Endless Online Patcher v{version}";
 
         SetPatchText("Getting local version...");
         var localVersion = _localVersionRepository.Get();
         SetPatchText("Getting remote version...");
 
-        _serverVersionFetcher
-            .Get()
-            .Switch(v =>
+        var result = await Task.Run(() => _serverVersionFetcher.Get());
+
+        result.Switch(v =>
             {
                 _serverVersion = v;
                 if (localVersion == v)
@@ -49,9 +49,9 @@ public partial class Main : Form
                 }
                 pbxExit.Visible = true;
             },
-            e =>
+            err =>
             {
-                SetPatchText(e.Value);
+                SetPatchText(err.Value);
                 pbxExit.Visible = true;
                 pbxPatch.Visible = false;
                 pbxSkip.Visible = false;
@@ -181,7 +181,6 @@ public partial class Main : Form
         _patching = false;
         pbxPatch.Visible = false;
         pbxLaunch.Visible = true;
-        Thread.Sleep(10);
     }
 
     private void pbxLaunch_MouseDown(object sender, MouseEventArgs e)


### PR DESCRIPTION
## Summary

- Reverts to the pre-Avalonia WinForms UI — the app must be a Windows `.exe` to run under Proton on Steam Deck alongside `Endless.exe`
- Fixes several bugs found during code review
- Adds GitHub Actions workflow to automatically publish to GitHub Releases on push to `main`
- Adds `CLAUDE.md` with architecture and deployment notes

## Bug fixes

- **UI thread freeze** — `ServerVersionFetcher.Get()` was called synchronously on the UI thread; wrapped in `Task.Run` so the window doesn't freeze while connecting
- **Data race** — parallel file-copy tasks all incremented `completed++` without synchronization; replaced with `Interlocked.Increment`
- **Null-ref risk** — `Assembly.GetEntryAssembly().GetName().Version.ToString()` had no null guards; fixed with `?.` propagation
- **Missing config exclusion** — README promised the patcher skips `config/` to preserve local settings, but the code copied everything; now filters out `config/` files before copying
- **No connection timeout** — `TcpClient.Connect()` could hang indefinitely; replaced with `ConnectAsync().Wait(10s)` which surfaces a clean error message
- **Pointless `Thread.Sleep(10)`** — removed from the end of the patch handler

## CI/CD

`.github/workflows/release.yml` builds a `win-x64` self-contained single-file exe on `windows-latest` and creates/updates a GitHub Release tagged `v{AssemblyVersion}` on every push to `main`. Bump `AssemblyVersion` + `FileVersion` in `EoPatcher.UI.csproj` to cut a new versioned release.

## Test plan

- [ ] Merge with a merge commit (not squash) to preserve the revert history, or squash — either is fine since the Avalonia commits will no longer be reachable from `main`
- [ ] Confirm the Actions workflow triggers and produces `eopatcher.exe` in a GitHub Release after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)